### PR TITLE
Redis SortedSet - Deprecated delete()

### DIFF
--- a/redis-driver/src/main/java/org/jnosql/diana/redis/key/DefaultSortedSet.java
+++ b/redis-driver/src/main/java/org/jnosql/diana/redis/key/DefaultSortedSet.java
@@ -16,13 +16,13 @@
 package org.jnosql.diana.redis.key;
 
 
-import redis.clients.jedis.Jedis;
+import static java.util.stream.Collectors.toList;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 
-import static java.util.stream.Collectors.toList;
+import redis.clients.jedis.Jedis;
 
 /**
  * The default {@link SortedSet} implementation
@@ -127,7 +127,7 @@ class DefaultSortedSet implements SortedSet {
 
     @Override
     public void clear() {
-        delete();
+        jedis.del(key);
     }
 
     @Override

--- a/redis-driver/src/main/java/org/jnosql/diana/redis/key/SortedSet.java
+++ b/redis-driver/src/main/java/org/jnosql/diana/redis/key/SortedSet.java
@@ -85,7 +85,10 @@ public interface SortedSet {
 
     /**
      * Delete this SortedSet
+     *
+     * @deprecated As of release 0.0.5, replaced by {@link #clear()}
      */
+    @Deprecated
     void delete();
 
     /**


### PR DESCRIPTION
In all collections we are using clear() and in SortedSet delete().
Because of compatibility we are deprecating the method and not removing.