### PR TITLE
Removes double semicolon that was flagged by Checkstyle

### DIFF
--- a/mongodb-driver/src/main/java/org/jnosql/diana/mongodb/document/MongoDBDocumentCollectionManagerAsync.java
+++ b/mongodb-driver/src/main/java/org/jnosql/diana/mongodb/document/MongoDBDocumentCollectionManagerAsync.java
@@ -202,7 +202,7 @@ public class MongoDBDocumentCollectionManagerAsync implements DocumentCollection
         String collectionName = query.getDocumentCollection();
         com.mongodb.async.client.MongoCollection<Document> asyncCollection =
                 asyncMongoDatabase.getCollection(collectionName);
-        Bson mongoDBQuery = query.getCondition().map(DocumentQueryConversor::convert).orElse(EMPTY);;
+        Bson mongoDBQuery = query.getCondition().map(DocumentQueryConversor::convert).orElse(EMPTY);
         asyncCollection.deleteMany(mongoDBQuery, callBack);
     }
 


### PR DESCRIPTION
This is another tiny change to remove a double semicolon, in this case because it caused Checkstyle to fail the build during a Maven install.